### PR TITLE
DRF API views replacing the rpc4django /rpc endpoint for the mapgroups app

### DIFF
--- a/mapgroups/api.py
+++ b/mapgroups/api.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from django.conf import settings
 from django.contrib.auth.models import Group
+from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -16,7 +17,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from mapgroups.models import MapGroup
+from mapgroups.models import MapGroup, MapGroupMember
 
 
 class SharingGroupListView(APIView):
@@ -31,7 +32,16 @@ class SharingGroupListView(APIView):
     def get(self, request: Request) -> Response:
         data: list[dict[str, Any]] = []
 
-        for membership in request.user.mapgroupmember_set.all():
+        memberships = request.user.mapgroupmember_set.select_related(
+            'map_group__permission_group'
+        ).prefetch_related(
+            Prefetch(
+                'map_group__mapgroupmember_set',
+                queryset=MapGroupMember.objects.select_related('user'),
+            )
+        )
+
+        for membership in memberships:
             group = membership.map_group
             members = sorted(
                 member.user_name_for_group()

--- a/mapgroups/api.py
+++ b/mapgroups/api.py
@@ -44,7 +44,8 @@ class SharingGroupListView(APIView):
                 'is_mapgroup': True,
             })
 
-        for public_group in Group.objects.filter(name__in=settings.SHARING_TO_PUBLIC_GROUPS):
+        sharing_to_public_groups = getattr(settings, 'SHARING_TO_PUBLIC_GROUPS', [])
+        for public_group in Group.objects.filter(name__in=sharing_to_public_groups):
             data.append({
                 'group_name': public_group.name,
                 'group_slug': public_group.name,

--- a/mapgroups/api.py
+++ b/mapgroups/api.py
@@ -1,0 +1,92 @@
+"""DRF API views replacing the rpc4django /rpc endpoint for the mapgroups app.
+
+Replaces these former XML-RPC methods:
+    get_sharing_groups, update_map_group
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from mapgroups.models import MapGroup
+
+
+class SharingGroupListView(APIView):
+    """GET /api/sharing-groups/
+
+    Returns all map groups the authenticated user belongs to, plus any
+    public sharing groups defined in settings.SHARING_TO_PUBLIC_GROUPS.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        data: list[dict[str, Any]] = []
+
+        for membership in request.user.mapgroupmember_set.all():
+            group = membership.map_group
+            members = sorted(
+                member.user_name_for_group()
+                for member in group.mapgroupmember_set.all()
+            )
+            data.append({
+                'group_name': group.name,
+                'group_slug': group.permission_group.name,
+                'members': members,
+                'is_mapgroup': True,
+            })
+
+        for public_group in Group.objects.filter(name__in=settings.SHARING_TO_PUBLIC_GROUPS):
+            data.append({
+                'group_name': public_group.name,
+                'group_slug': public_group.name,
+                'members': [],
+                'is_mapgroup': False,
+            })
+
+        return Response(data)
+
+
+class MapGroupUpdateView(APIView):
+    """PATCH /api/map-groups/<pk>/
+
+    Selectively updates name, blurb, and/or is_open for a map group owned
+    by the authenticated user.
+
+    Body keys (all optional):
+        update_name  (bool)  + name  (str)
+        update_blurb (bool)  + blurb (str)
+        update_is_open (bool) + is_open (bool)
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request: Request, pk: int) -> Response:
+        mg = get_object_or_404(MapGroup, id=pk, owner=request.user)
+        options: dict[str, Any] = request.data
+        changed = False
+
+        if options.get('update_name'):
+            mg.name = options['name']
+            changed = True
+
+        if options.get('update_blurb'):
+            mg.blurb = options['blurb']
+            changed = True
+
+        if options.get('update_is_open'):
+            mg.is_open = options['is_open']
+            changed = True
+
+        if changed:
+            mg.save()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/mapgroups/urls.py
+++ b/mapgroups/urls.py
@@ -1,6 +1,5 @@
 """URL configuration for the mapgroups app."""
 from django.urls import path, re_path
-
 from mapgroups.views import (
     MapGroupDetailView, MapGroupCreate, MapGroupListView,
     JoinMapGroupActionView, RequestJoinMapGroupActionView,
@@ -57,3 +56,12 @@ def urls(namespace='mapgroups'):
     internally, they are referred to as app_name:urlname.
     """
     return (urlpatterns, 'mapgroups', namespace)
+
+
+# DRF API patterns — mounted at /api/ by the project urls.py
+from mapgroups.api import SharingGroupListView, MapGroupUpdateView  # noqa: E402
+
+api_urlpatterns = [
+    re_path(r'^sharing-groups/$', SharingGroupListView.as_view()),
+    re_path(r'^map-groups/(?P<pk>\d+)/$', MapGroupUpdateView.as_view()),
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rpc4django
+# rpc4django removed — replaced by djangorestframework API views


### PR DESCRIPTION
DRF API views replacing the rpc4django /rpc endpoint for the mapgroups app.

Replaces these former XML-RPC methods:
    get_sharing_groups, update_map_group

Adds API endpoints